### PR TITLE
Retira proposições repetidas da busca do google Trends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,12 @@ RUN R -e "install.packages('glmnet',dependencies=TRUE, repos='http://cran.rstudi
 RUN R -e "install.packages('here',dependencies=TRUE, repos='http://cran.rstudio.com/')"
 RUN R -e "install.packages('fuzzyjoin',dependencies=TRUE, repos='http://cran.rstudio.com/')"
 RUN R -e "install.packages('dotenv', dependencies=TRUE, repos='http://cran.rstudio.com/')"
+RUN R -e "devtools::install_version('rlang', version = '0.4.10', repos = 'http://cran.rstudio.com/')"
 RUN R -e "devtools::install_github('ekstroem/MESS')"
 RUN R -e "devtools::install_github('ropensci/rtweet')"
 RUN R -e "devtools::install_github('analytics-ufcg/rcongresso')"
 
+RUN apt-get update
 RUN apt-get install -y python3-pip
 
 RUN pip3 install pandas

--- a/fetch_google_trends.py
+++ b/fetch_google_trends.py
@@ -130,7 +130,7 @@ def agrupa_por_semana(pop_df):
     '''
 
     pop_df = pop_df.reset_index()
-    pop_df = pop_df.groupby(['id_ext', pd.Grouper(key='date', freq='W-MON'), 'casa', 'interesse']).agg('max')
+    pop_df = pop_df.groupby(['id_ext', pd.Grouper(key='date', freq='W-MON'), 'casa']).agg('max')
     pop_df = pop_df.reset_index()
     pop_df['date'] = pd.to_datetime(pop_df['date']) - pd.to_timedelta(7, unit = 'd')
 
@@ -228,7 +228,6 @@ def write_csv_popularidade(apelidos, lote_dia, export_path):
             id_ext = str(row['id_ext'])
             casa = row['casa']
             id_leggo = row['id_leggo']
-            interesse = row['interesse']
 
             # separa o nome da proposição do ano e trata MPVs
             nome_simples = formata_nome_formal(nome_formal) 
@@ -244,8 +243,7 @@ def write_csv_popularidade(apelidos, lote_dia, export_path):
                     'id_ext',
                     'date',
                     'casa',
-                    'interesse',
-                    nome_formal,
+                    'nome_formal',
                     'isPartial',
                     'max_pressao_principal',
                     'max_pressao_rel',
@@ -257,7 +255,7 @@ def write_csv_popularidade(apelidos, lote_dia, export_path):
             tentativas = int(os.getenv("TRENDS_RETRIES"))
             for n in range(0, tentativas):
                 try:
-                    print('Tentativa %s de coletar a popularidade da proposição %s da agenda %s' %(n+1, nome_formal, interesse))
+                    print('Tentativa %s de coletar a popularidade da proposição %s' %(n+1, nome_formal))
                     # Recupera as informações de popularidade a partir dos termos
                     pop_df = get_popularidade(termos, timeframe)
                     break
@@ -282,11 +280,10 @@ def write_csv_popularidade(apelidos, lote_dia, export_path):
                 pop_df['id_leggo'] = id_leggo
                 pop_df['id_ext'] = id_ext
                 pop_df['casa'] = casa
-                pop_df['interesse'] = interesse
                 pop_df = agrupa_por_semana(pop_df)
 
             # Escreve resultado da consulta para uma proposição
-            filename = export_path + 'pop_' + str(id_leggo) + '_' + str(interesse) + '.csv'
+            filename = export_path + 'pop_' + str(id_leggo) + '.csv'
             pop_df.to_csv(filename, encoding='utf8', index=False)
 
             # Esperando para a próxima consulta do trends

--- a/gera_entrada_google_trends.R
+++ b/gera_entrada_google_trends.R
@@ -18,11 +18,6 @@ get_args <- function() {
                           default="data/proposicoes.csv",
                           help=.HELP, 
                           metavar="character"),
-    optparse::make_option(c("-i", "--interesses_filepath"), 
-                          type="character", 
-                          default="data/interesses.csv",
-                          help=.HELP, 
-                          metavar="character"),
     optparse::make_option(c("-a", "--apelidos_filepath"), 
                           type="character", 
                           default="data/apelidos.csv",
@@ -60,7 +55,6 @@ args <- get_args()
 print(args)
 
 proposicoes_filepath <- args$proposicoes_filepath
-interesses_filepath <- args$interesses_filepath
 apelidos_filepath <- args$apelidos_filepath
 update_flag <- args$update_flag
 config_path <- args$config_filepath
@@ -73,8 +67,7 @@ if (update_flag == 1 | !file.exists(apelidos_filepath)) {
   load_dot_env(config_path)
 
   proposicoes <- read_csv(proposicoes_filepath)
-  interesses <- read_csv(interesses_filepath)
-  df_apelidos <- generate_keywords(proposicoes, interesses)
+  df_apelidos <- generate_keywords(proposicoes)
  
   lotes <- get_lotes(df_apelidos)
   df_apelidos <- df_apelidos %>% mutate(lote = lotes)

--- a/scripts/keywords/generate_keywords.R
+++ b/scripts/keywords/generate_keywords.R
@@ -2,23 +2,14 @@
 #' @description A partir do dataframe de proposições, retorna um dataframe contendo as colunas
 #' nome_formal e apelido processadas.
 #' @param proposicoes Dataframe de proposições
-#' @param interesses Dataframe de interesses
 #' @return Dataframe com apelido e nome formal processadas.
-generate_keywords <- function(proposicoes, interesses) {
+generate_keywords <- function(proposicoes) {
   library(tidyverse)
-  source(here::here("scripts/utils/utils.R"))
   
-  prop_interesses <- proposicoes %>% 
-    left_join(interesses %>% 
-                select(id_leggo, interesse, apelido, keywords), 
-              by = c("id_leggo"))
-  
-  df_apelidos <- 
-    prop_interesses %>% 
-    mutate(apelido = .remove_pontuacao(apelido),
-           keywords = .remove_pontuacao(keywords),
-           nome_formal = paste0(sigla_tipo, " ", numero, "/", lubridate::year(data_apresentacao))) %>% 
-    select(id_leggo, id_ext, casa, apelido, nome_formal, apresentacao = data_apresentacao, interesse, keywords)
+  df_apelidos <-
+    proposicoes %>%
+    select(id_leggo, id_ext, casa, nome_formal = sigla, apresentacao = data_apresentacao) %>%
+    distinct(id_leggo, id_ext, casa, .keep_all = T)
   
   return(df_apelidos)
 }

--- a/scripts/popularity/export_popularity.R
+++ b/scripts/popularity/export_popularity.R
@@ -23,7 +23,12 @@ option_list = list(
     help = "nome da pasta destino dos arquivos de saída com a popoularidade do Google Trends [default= %default]",
     metavar = "character"
   ),
-  
+  make_option(
+    c("-i", "--interesses_filepath"), 
+    type="character", 
+    default="data/interesses.csv",
+    help="caminho do arquivo de interesses [default= %default]", 
+    metavar="character"),
   make_option(
     c("-o", "--out"),
     type = "character",
@@ -37,6 +42,7 @@ opt_parser = OptionParser(option_list = option_list)
 opt = parse_args(opt_parser)
 
 twitter_trends_path <- opt$tt
+interesses_filepath <- opt$interesses_filepath
 pops_folderpath <- opt$gt
 output_path <- opt$out
 
@@ -68,7 +74,7 @@ twitter_trends <- readr::read_csv(
 )
 
 cat("Gerando dados de popularidade do Google Trends e Twitter...\n")
-popularity <- combine_indexes(twitter_trends, pops_folderpath)
+popularity <- combine_indexes(twitter_trends, pops_folderpath, interesses_filepath)
 
 write_csv(popularity, paste0(output_path))
 


### PR DESCRIPTION
### Mudanças
- Retira o interesse e demais colunas não utilizadas no momento (apelido, keywords), deixando a lista de proposições menor e diferentes, considerando id_leggo, id_ext e casa;
- Altera demais scripts para considerar mudança;
- Modifica processamento posterior ao trends e twitter para mapear id_leggo aos interesses.
